### PR TITLE
debian-packaging: allow to override wazo distribution

### DIFF
--- a/roles/debian-packaging/default/main.yaml
+++ b/roles/debian-packaging/default/main.yaml
@@ -1,0 +1,2 @@
+---
+wazo_distribution: wazo-dev-buster

--- a/roles/debian-packaging/tasks/main.yaml
+++ b/roles/debian-packaging/tasks/main.yaml
@@ -22,7 +22,7 @@
 - name: Configure Wazo dev repository
   become: yes
   apt_repository:
-    repo: deb http://mirror.wazo.community/debian/ wazo-dev-buster main
+    repo: "deb http://mirror.wazo.community/debian/ {{ wazo_distribution }} main"
     state: present
 
 - name: Copy script to validate versions


### PR DESCRIPTION
why: used to build xivo-acceptance-server package