### PR TITLE
tox-integration: rebuild db with sibling xivo-manage-db

### DIFF
--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -63,6 +63,9 @@
       TEST_LOGS: "verbose"
       INTEGRATION_TEST_TIMEOUT: "{{ integration_test_timeout | default(omit) }}"
       TOX_TESTENV_PASSENV: "INTEGRATION_TEST_TIMEOUT WAZO_TEST_DOCKER_LOGS_DIR WAZO_TEST_DOCKER_LOGS_ENABLED WAZO_TEST_DOCKER_OVERRIDE_EXTRA WAZO_TEST_NO_DOCKER_COMPOSE_PULL TEST_LOGS"
+      MANAGE_DB_DIR: "{{ zuul.projects.values() | list | json_query(manage_db_query) | first | default('') }}"
+  vars:
+    manage_db_query: "[?short_name=='xivo-manage-db'].src_dir"
 
 - name: Emit docker compose override file
   debug:


### PR DESCRIPTION
Why:

* We need to run the integration tests of wazo-confd with an up-to-date
database