### PR TITLE
wazo-tox: don't fail when no xivo-manage-db sibling PR

### DIFF
--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -58,7 +58,7 @@
   set_fact:
     integration_env:
       INTEGRATION_TEST_TIMEOUT: "{{ integration_test_timeout | default(omit) }}"
-      MANAGE_DB_DIR: "{{ ansible_env.PWD }}/{{ zuul.projects.values() | list | json_query(manage_db_query) | first | default('') }}"
+      MANAGE_DB_DIR: "{{ ansible_env.PWD + '/' + manage_db_dir_relative if manage_db_dir_relative else '' }}"
       TEST_LOGS: "verbose"
       WAZO_TEST_DOCKER_LOGS_ENABLED: 1
       WAZO_TEST_NO_DOCKER_COMPOSE_PULL: 1
@@ -72,7 +72,7 @@
         WAZO_TEST_DOCKER_OVERRIDE_EXTRA
         WAZO_TEST_NO_DOCKER_COMPOSE_PULL
   vars:
-    manage_db_query: "[?short_name=='xivo-manage-db'].src_dir"
+    manage_db_dir_relative: "{{ zuul.projects.values() | list | json_query([?short_name=='xivo-manage-db'].src_dir) | first | default('') }}"
 
 - name: Emit docker compose override file
   debug:


### PR DESCRIPTION
When there is no PR from `xivo-manage-db` (or a PR alread merged), MANAGE_DB_DIR would have the value `/home/worker`, failing the build of the database docker image.