### PR TITLE
wazo-tox: fix query to find xivo-manage-db path

### DIFF
--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -72,7 +72,8 @@
         WAZO_TEST_DOCKER_OVERRIDE_EXTRA
         WAZO_TEST_NO_DOCKER_COMPOSE_PULL
   vars:
-    manage_db_dir_relative: "{{ zuul.projects.values() | list | json_query([?short_name=='xivo-manage-db'].src_dir) | first | default('') }}"
+    manage_db_query: "[?short_name=='xivo-manage-db'].src_dir"
+    manage_db_dir_relative: "{{ zuul.projects.values() | list | json_query(manage_db_query) | first | default('') }}"
 
 - name: Emit docker compose override file
   debug:


### PR DESCRIPTION
Error was: template error while templating string: unexpected char '?'
at 47.