### PR TITLE
wazo-tox: mount sibling packages in Python2 paths too

### DIFF
--- a/roles/wazo-tox/library/docker_sibling_packages.py
+++ b/roles/wazo-tox/library/docker_sibling_packages.py
@@ -58,6 +58,11 @@ def main():
         package = get_package_name(tox_python, root)
         volumes.add(
             "{root}/{package}:"
+            "/opt/venv/lib/python2.7/site-packages/{package}".format(
+                root=os.path.realpath(root), package=package
+            ))
+        volumes.add(
+            "{root}/{package}:"
             "/opt/venv/lib/python3.7/site-packages/{package}".format(
                 root=os.path.realpath(root), package=package
             ))


### PR DESCRIPTION
Why:

* Needed for wazo-sysconfd, wazo-confgend and wazo-provd