### PR TITLE
debian-packaging: allow multiple debian repos for install

### DIFF
--- a/roles/debian-packaging/tasks/main.yaml
+++ b/roles/debian-packaging/tasks/main.yaml
@@ -22,8 +22,9 @@
 - name: Configure Wazo dev repository
   become: yes
   apt_repository:
-    repo: "deb http://mirror.wazo.community/debian/ {{ wazo_distribution }} main"
+    repo: "deb http://mirror.wazo.community/debian/ {{ item }} main"
     state: present
+  loop: "{{ wazo_distributions | default([wazo_distribution]) }}"
 
 - name: Copy script to validate versions
   copy:


### PR DESCRIPTION
Why:

* xivo-dev-tools requires packages from wazo-dev-buster