### PR TITLE
add workaround to fix bindep on vm

### DIFF
--- a/playbooks/wazo-tox-integration/pre.yaml
+++ b/playbooks/wazo-tox-integration/pre.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  tasks:
+    - name: Update package lists (workaround for bindep role)
+      apt:
+        update_cache: true
+      become: yes

--- a/zuul.d/wazo_jobs.yaml
+++ b/zuul.d/wazo_jobs.yaml
@@ -34,6 +34,7 @@
     vars:
       docker_install_siblings: true
       tox_envlist: integration
+    pre-run: playbooks/wazo-tox-integration/pre.yaml
     run: playbooks/wazo-tox-integration/run.yaml
     nodeset: vm-debian-11-m1s
 


### PR DESCRIPTION
why: to install packages found by bindep, cache must be updated.
Since bindep use generic ansible module "package". No 'apt update' is
performed.

Note:
We didn't have this issue on Buster because another role, executed
before bindep, was executed and run an 'apt update'. It is ensure-pip:
From Buster:
```
LOOP [ensure-pip : Install pip from packages]
vm-debian-10-m1s | included: /var/lib/zuul/builds/d27d7e1c9a144952a8e286322da64cd0/untrusted/project_0/opendev.org/zuul/zuul-jobs/roles/ensure-pip/tasks/Debian.yaml
```

From Bullseye
```
LOOP [ensure-pip : Install pip from packages]
vm-debian-11-m1s | skipping: Conditional result was False
```