### PR TITLE
ensure ansible collections is installed for lint

### DIFF
--- a/roles/ensure-ansible-lint/tasks/main.yaml
+++ b/roles/ensure-ansible-lint/tasks/main.yaml
@@ -1,3 +1,6 @@
 ---
 - name: Ensure ansible-lint is installed
   shell: type ansible-lint || pip install --user ansible-lint
+
+- name: Ensure ansible collections (2.10.7) are installed for lint
+  shell: pip show ansible || pip install --user ansible==2.10.7


### PR DESCRIPTION
why: otherwise ansible-lint will raise an error because collections are
not available