### PR TITLE
read first package only if multiple are found

### DIFF
--- a/roles/wazo-tox/library/docker_sibling_packages.py
+++ b/roles/wazo-tox/library/docker_sibling_packages.py
@@ -14,7 +14,7 @@ def get_package_name(tox_python, root):
         cwd=os.path.abspath(root))
     top_level = glob.glob(f"{root}/*.egg-info/top_level.txt")[0]
     with open(top_level) as f:
-        return f.read().strip()
+        return f.readline().strip()
 
 
 def main():


### PR DESCRIPTION
* Fixes an issue when multiple names are in the toplevel of a package. This fix returns the first value only.  If multiple are needed in the future, it will have to be adapted.

e.g: issue prevents PR to depend on another using wazo-bus:
     wazo-bus exposes 2 toplevel
       - wazo_bus
       - xivo_bus (which is an alias to wazo_bus for compatiblity)