### PR TITLE
fix encrypted value for mattermost api key

### DIFF
--- a/zuul.d/wazo_secrets.yaml
+++ b/zuul.d/wazo_secrets.yaml
@@ -3,13 +3,13 @@
     name: mattermost
     data:
       api_key: !encrypted/pkcs1-oaep
-        - IJaEUDAHQwzxhaRDpnSv2CfDcPky4O1FIezFWtQyI2Oj9kn96qaUu9ET1Bo/tUdWr8tl7
-          3s3VcF/Za4eP3wZTafgDe26e+ebXwzHYWZ0Mwb9mrhxU2Y5p80BM3vaa8Ixo68+ayHRul
-          1mjpC0NJmf1v/ErhcEt0HQ78xfoo1V0QZ2Vjgnxfc4S1X4/sFFpDUhR6YWLBOH4rw7kad
-          yY1s16Qm6g7nksW/D7ZuYrFTs1TprpVJWrUqfr30rUf6gs2Wni8ht0AH4uTTh2d0sAMvK
-          WR8+bTN5e++zHudphRi1qmgaWDXGeDnhwoM1iBIx6jXO2xCq0cXurrOOpcsXgu6wooT1S
-          7JH/A0jkOe4bbIcITIeV+NcHGnXVIjirW9RZTsaj99t6p5KVjde82IrBj/MosB0nxOa3Z
-          TWFI/vaVAcY5g++3ngVJ0MCXUD/k+wYTGgUy8Q9/Yv0eLYCih1A7C/s2Q4zRivZuv2N6H
-          gpqvMqa8T67Pjd+E0K0/Ks+lLtCofV6fxfnrnQmXdb+tqM8CvKR8GWwSiaqrct0gSBtzm
-          ve15pvraTmJcARtLg3GVcD05HzyxXn56rKV2YHvhrQacnv3M+Vtvp51Cwofrdy9PynWng
-          hLo4Csgc5o8hqQdZhS5A3f2LEkc1IMog0DRkvSdxIwsSyCBJAr3RFlHMjsuNOU=
+        - cRIRYo4JGuv28a7Kv+4xIzigmk8xiawLIKYEQSwzBmIfEFsjAxD77kQXlHVPW0JDPdJzo
+          tPNfPG+Hwq/RwH2ltJGbHsFClwOp91Geb5GzzClMMgonWWpUFL2uhSsPAPi0YX5ODfB4s
+          tJZGJc1yo78kzYcyQe6hN8Sye13a73UHgACUSwUUCpb0pyIl24iOVHsINHkHC6vJ5vwgi
+          /7OfnUsbKsqSm/QXxycnQggbJeLqlL+9eg8XBkNlV4sBfewuY4dd6ik8vMGybs4fm/d+1
+          EexD42+BAqkVQetF3yAbM6D9G42/rRYKjHc90DaViTKszJUqr9Hyc6sSD0PxvL83EQrbK
+          5dknxYTvTybgamU1VaTK0PIdmGbskpaZgTAJRAXOc3w4wWi559KymBC78Ry5m6JFQpnlA
+          ZCN8yNpnzcwdbxd7kdB0f3SO/arvxAF4oaLcyyhzVVuIxdcpZM7q2+s8ylNECZi33DAyi
+          kZp+0aKmWSu7u7/Y0dcvXzkoyLA0bPa3GQE/Vr+2x2j095s13cT4KMbSaNpARc4aFrorB
+          PnRE7PFbnPMGLKbPoglJLibkHDMCPd2ydJV2RxqdqWvcdeA6juDKlsxW6S+W93KK6SJx6
+          8E8QJ335plq4XdNwqCU12V1A9Js6ddxeu/hs0AIaAVzhgH1UCoSJkmXx51MgLQ=


### PR DESCRIPTION
Encrypted value makes the zuul periodic job fail. Re-encrypting using the following syntax:

`zuul-client encrypt --tenant local --project github.com/TinxHQ/wazo-production-sf-jobs --secret-name mattermost --field-name api_key --infile /etc/zuul/mm_webhook_id_unencrypted --outfile /etc/zuul/mm_webhook_id_sf_jobs.yaml`