### PR TITLE
remove unused TOX_TESTENV_PASSENV

### DIFF
--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -102,14 +102,7 @@
       WAZO_TEST_DOCKER_LOGS_ENABLED: 1
       WAZO_TEST_NO_DOCKER_COMPOSE_PULL: 1
       WAZO_TEST_DOCKER_LOGS_DIR: "/tmp/docker-logs"
-      TOX_TESTENV_PASSENV: >-
-        INTEGRATION_TEST_TIMEOUT
-        MANAGE_DB_DIR
-        TEST_LOGS
-        WAZO_TEST_DOCKER_LOGS_DIR
-        WAZO_TEST_DOCKER_LOGS_ENABLED
-        WAZO_TEST_DOCKER_OVERRIDE_EXTRA
-        WAZO_TEST_NO_DOCKER_COMPOSE_PULL
+      # WARNING: To be effective, variables must be declared in the `pass_env` config of the tox.ini file for each project
   vars:
     manage_db_query: "[?short_name=='xivo-manage-db'].src_dir"
     manage_db_dir_relative: "{{ zuul.projects.values() | list | json_query(manage_db_query) | first | default('') }}"


### PR DESCRIPTION
why: This variable has been removed since tox 4 (2022-12-07)
Good practice is to declare these variables in tox.ini of each project.
It will allow dev to use these variables too