### PR TITLE
tox-integration-tests: gzip docker logs

### DIFF
--- a/playbooks/wazo-tox/post.yaml
+++ b/playbooks/wazo-tox/post.yaml
@@ -1,17 +1,22 @@
 ---
 - hosts: all
   tasks:
-    - name: check if rules file exists
+    - name: Check if integration logs exist
       stat:
         path: /tmp/docker-logs
       register: docker_logs
 
+    - name: Compress integration logs
+      shell: |
+        gzip {{ docker_logs.stat.path }}/*
+      when: docker_logs.stat.exists
+
     - name: Fetch integration logs
       synchronize:
-        src: '/tmp/docker-logs/'
+        src: '{{ docker_logs.stat.path }}/'
         dest: '{{ zuul.executor.log_root }}/docker/'
         mode: pull
         copy_links: true
         verify_host: true
         rsync_opts: []
-      when: docker_logs.stat.exists == True
+      when: docker_logs.stat.exists


### PR DESCRIPTION
Why:

* One run of integration tests can use 100MB+ just for docker logs