### PR TITLE
Pull request for WAZO-3892-code-coverage

### DIFF
--- a/playbooks/wazo-tox/post.yaml
+++ b/playbooks/wazo-tox/post.yaml
@@ -26,11 +26,19 @@
         path: /tmp/integration-tests-coverage
       register: coverage_artifacts
 
+    - name: Check if coverage files exist
+      find:
+        paths: /tmp/integration-tests-coverage/
+      register: coverage_files_found
+      when: coverage_artifacts.stat.exists
+
     - name: Install coverage tool
       pip:
         name: coverage
         state: present
-      when: coverage_artifacts.stat.exists
+      when:
+        - coverage_artifacts.stat.exists
+        - coverage_files_found.matched > 0
 
     - name: Generate coverage report
       shell: |
@@ -38,7 +46,9 @@
         python3 -m coverage html --data-file {{ coverage_artifacts.stat.path }}/combined.coverage --directory {{ coverage_artifacts.stat.path }}/report-html
       args:
         chdir: "{{ zuul.project.src_dir }}"
-      when: coverage_artifacts.stat.exists
+      when:
+        - coverage_artifacts.stat.exists
+        - coverage_files_found.matched > 0
 
     - name: Fetch coverage HTML report
       synchronize:
@@ -48,4 +58,6 @@
         copy_links: true
         verify_host: true
         rsync_opts: []
-      when: coverage_artifacts.stat.exists
+      when:
+        - coverage_artifacts.stat.exists
+        - coverage_files_found.matched > 0

--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -100,9 +100,9 @@
       MANAGE_DB_DIR: "{{ ansible_env.PWD + '/' + manage_db_dir_relative if manage_db_dir_relative else '' }}"
       TEST_LOGS: "verbose"
       WAZO_TEST_COVERAGE_DIR: "/tmp/integration-tests-coverage"
-      WAZO_TEST_COVERAGE_ENABLED: "{{ 1 if integration_test_coverage_service_name is defined else 0 }}"
-      WAZO_TEST_DOCKER_LOGS_ENABLED: 1
+      WAZO_TEST_COVERAGE_ENABLED: 1
       WAZO_TEST_DOCKER_LOGS_DIR: "/tmp/docker-logs"
+      WAZO_TEST_DOCKER_LOGS_ENABLED: 1
       WAZO_TEST_NO_DOCKER_COMPOSE_PULL: 1
       # WARNING: To be effective, variables must be declared in the `pass_env` config of the tox.ini file for each project
   vars:

--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -101,7 +101,6 @@
       TEST_LOGS: "verbose"
       WAZO_TEST_COVERAGE_DIR: "/tmp/integration-tests-coverage"
       WAZO_TEST_COVERAGE_ENABLED: "{{ 1 if integration_test_coverage_service_name is defined else 0 }}"
-      WAZO_TEST_COVERAGE_SERVICE_NAME: "{{ integration_test_coverage_service_name | default(omit) }}"
       WAZO_TEST_DOCKER_LOGS_ENABLED: 1
       WAZO_TEST_DOCKER_LOGS_DIR: "/tmp/docker-logs"
       WAZO_TEST_NO_DOCKER_COMPOSE_PULL: 1


### PR DESCRIPTION
## remove COVERAGE_SERVICE_NAME

why: avoid to duplicate information, this info is already available in
wazo-test-helpers test class

## always enable code coverage

why: avoid to add configuration in all repo

the code will ignore when no coverage file is available