### PR TITLE
increase vm for ansible-uc installation

### DIFF
--- a/zuul.d/wazo_jobs.yaml
+++ b/zuul.d/wazo_jobs.yaml
@@ -89,4 +89,4 @@
       wazo_distribution_upgrade: wazo-dev-bullseye
     required-projects:
       - wazo-platform/wazo-ci
-    nodeset: vm-debian-11-m1s
+    nodeset: vm-debian-11-m1m


### PR DESCRIPTION
why: Avoid OOM killer
Tests was fine on January, but not anymore now ... we have probably
increased our memory footprint

Test done with https://github.com/wazo-platform/wazo-ansible/pull/127