### PR TITLE
wazo-acceptance: adds playwright dependencies install

### DIFF
--- a/playbooks/wazo-acceptance/pre.yaml
+++ b/playbooks/wazo-acceptance/pre.yaml
@@ -33,3 +33,35 @@
       command: "ansible-galaxy install -r requirements-postgresql.yml"
       args:
         chdir: "{{ zuul.project.src_dir }}/../wazo-ansible"
+
+    - name: Install playwright dependencies
+      become: yes
+      apt:
+        state: present
+        name:
+          - libnss3
+          - libnspr4
+          - libatk1.0-0
+          - libatk-bridge2.0-0
+          - libcups2
+          - libdrm2
+          - libatspi2.0-0
+          - libx11-6
+          - libxcomposite1
+          - libxdamage1
+          - libxext6
+          - libxfixes3
+          - libxrandr2
+          - libgbm1
+          - libxcb1
+          - libxkbcommon0
+          - libpango-1.0-0
+          - libcairo2
+          - libasound2
+          - libx11-xcb1
+          - libxcursor1
+          - libxi6
+          - libgtk-3-0
+          - libpangocairo-1.0-0
+          - libcairo-gobject2
+          - libgdk-pixbuf-2.0-0


### PR DESCRIPTION
**why**
playwright needs a bunch of dependencies to correctly run