### PR TITLE
nodesets: use vm-debian-12-* only

### DIFF
--- a/zuul.d/wazo_jobs.yaml
+++ b/zuul.d/wazo_jobs.yaml
@@ -82,7 +82,7 @@
     parent: wazo-tox
     vars:
       tox_envlist: py311
-    nodeset: pod-debian-12
+    nodeset: vm-debian-12-m1s
 
 - job:
     name: debian-packaging-bullseye

--- a/zuul.d/wazo_project_templates.yaml
+++ b/zuul.d/wazo_project_templates.yaml
@@ -76,11 +76,11 @@
     wazo-check:
       jobs:
         - tox-linters:
-            nodeset: pod-debian-12
+            nodeset: vm-debian-12-m1s
     wazo-gate:
       jobs:
         - tox-linters:
-            nodeset: pod-debian-12
+            nodeset: vm-debian-12-m1s
     auto-merge:
       jobs:
         - noop


### PR DESCRIPTION
**why**
We are unable to run pod-debian-12 containers, nodepool is unable to SSH to it. This is blocking other projects so while we test it we need to unlock